### PR TITLE
Fix some custom controls-related bugs

### DIFF
--- a/controls.html
+++ b/controls.html
@@ -48,15 +48,10 @@ input {
             <tr>
                 <th>Key</th>
                 <th>Move</th>
+                <th></th>
             </tr>
 
             <tbody id="keymapsbody">
-                <tr>
-                    <td><input value="."/></td>
-                    <td><input value="E'" /></td>
-                    <td><button> ✅ </button></td>
-                    <td><button> ❌ </button></td>
-                </tr>
             </tbody>
         </table>
         <br />
@@ -115,15 +110,15 @@ function editField(i) {
     moveField.value = v;
     move.appendChild(moveField);
 
+    let buttonsTd = document.createElement("td");
+
     let escapeButton = document.createElement("button");
     escapeButton.innerText = "❌";
     escapeButton.onclick = _e => {
         rerender();
     };
 
-    let escapeButtonTd = document.createElement("td");
-    escapeButtonTd.appendChild(escapeButton);
-    tr.appendChild(escapeButtonTd);
+    buttonsTd.appendChild(escapeButton);
 
     let acceptButton = document.createElement("button");
     acceptButton.innerText = "✅";
@@ -132,9 +127,7 @@ function editField(i) {
         rerender();
     };
 
-    let acceptButtonTd = document.createElement("td");
-    acceptButtonTd.appendChild(acceptButton);
-    tr.appendChild(acceptButtonTd);
+    buttonsTd.appendChild(acceptButton);
 
     let removeButton = document.createElement("button");
     removeButton.innerText = "🗑";
@@ -143,9 +136,9 @@ function editField(i) {
         rerender();
     };
 
-    let removeButtonTd = document.createElement("td");
-    removeButtonTd.appendChild(removeButton);
-    tr.appendChild(removeButtonTd);
+    buttonsTd.appendChild(removeButton);
+
+    tr.appendChild(buttonsTd);
 
     tr.onclick = null;
 }
@@ -167,6 +160,8 @@ function rerender(quiet=false) {
         let tr = document.createElement("tr");
         tr.appendChild(key);
         tr.appendChild(move);
+
+        tr.appendChild(document.createElement("td"));
 
         keymapsBody.appendChild(tr);
         tr.onclick = _e => editField(i);

--- a/controls.html
+++ b/controls.html
@@ -85,6 +85,8 @@ function editField(i) {
     let tr = keymapsBody.children[i];
     let key = tr.children[0];
     let move = tr.children[1];
+    let buttonsTd = tr.children[2];
+
 
     let newKc = k;
 
@@ -110,8 +112,7 @@ function editField(i) {
     moveField.value = v;
     move.appendChild(moveField);
 
-    let buttonsTd = document.createElement("td");
-
+    buttonsTd.innerHTML = "";
     let escapeButton = document.createElement("button");
     escapeButton.innerText = "❌";
     escapeButton.onclick = _e => {
@@ -137,8 +138,6 @@ function editField(i) {
     };
 
     buttonsTd.appendChild(removeButton);
-
-    tr.appendChild(buttonsTd);
 
     tr.onclick = null;
 }

--- a/js/controls.js
+++ b/js/controls.js
@@ -46,6 +46,7 @@ class Listener {
     }
 
     keydown(e) {
+        if (e.target !== document.body) { return; }
         for (let [combo, fn] of this.combos) {
             if (combo.matches(e)) {
                 fn(e);


### PR DESCRIPTION
This pull request fixes two bugs reported in the discord server.

1) The new control system "swallowed" all matching keyboard events, regardless of whether the cube was "active" or not, meaning you could not type certain letters into text boxes

2) Some browsers, such as Chrome, did not render the table in controls.html properly when a binding was being edited.

I've done some quick tests in Firefox, Chrome and Safari and everything seems to work properly. 